### PR TITLE
Wait for services init to serve

### DIFF
--- a/vertebrae/core.py
+++ b/vertebrae/core.py
@@ -43,12 +43,8 @@ class Server:
     def __init__(self, services, applications):
         self.setup_logger(path=os.getenv('logfile'))
         self.loop = asyncio.new_event_loop()
+        self.applications = applications
         asyncio.set_event_loop(self.loop)
-
-        for app in applications:
-            app.attach_routes()
-            app.attach_gui()
-            self.loop.run_until_complete(app.start())
         for service in services:
             Service.enroll(service.log.name, service)
         create_log('server').info(f'Serving {len(applications)} apps with {len(services)} services')
@@ -57,6 +53,11 @@ class Server:
         try:
             self.start_probe()
             self.loop.run_until_complete(Service.initialize())
+            for app in self.applications:
+                app.attach_routes()
+                app.attach_gui()
+                self.loop.run_until_complete(app.start())
+            logging.info("ready to serve")
             self.loop.run_forever()
         except KeyboardInterrupt:
             logging.info('Keyboard interrupt received')

--- a/vertebrae/core.py
+++ b/vertebrae/core.py
@@ -88,7 +88,6 @@ class Application:
         self.routes = routes
         self.template_directory = template_directory
         self.application = web.Application(client_max_size=client_max_size)
-        self.application.router.add_route('GET', '/ping', self.pong)
         self.cors = aiohttp_cors.setup(self.application, defaults={
             "*": aiohttp_cors.ResourceOptions(
                     expose_headers="*",
@@ -97,6 +96,7 @@ class Application:
         })
 
     def attach_routes(self):
+        self.application.router.add_route('GET', '/ping', self.pong)
         for collection in self.routes:
             for route in collection.routes():
                 route_type = type(route)


### PR DESCRIPTION
- Wait for services initialization before serving content. That should take care of our deployment issue in prod.
- That wait_start config allows for overriding this behaviour for local/dev.